### PR TITLE
Add eatery location information to datastore

### DIFF
--- a/functions/dining.js
+++ b/functions/dining.js
@@ -53,6 +53,11 @@ function insertData(data) {
             }))
           }))
         }));
+        const location = {
+          address: eatery.location,
+          area: eatery.campusArea.descrshort,
+          coordinates: eatery.coordinates,
+        }
         const key = datastore.key(['dining', `${eatery.slug}`]);
         if (EATERYNAME_MAP[eatery.slug] !== null) {
           datastore.upsert(
@@ -60,7 +65,8 @@ function insertData(data) {
               key,
               data: {
                 id: EATERYNAME_MAP[eatery.slug] || 'unknown',
-                weeksMenus
+                weeksMenus,
+                location
               }
             },
             err => {

--- a/functions/dining.js
+++ b/functions/dining.js
@@ -56,8 +56,8 @@ function insertData(data) {
         const location = {
           address: eatery.location,
           area: eatery.campusArea.descrshort,
-          coordinates: eatery.coordinates,
-        }
+          coordinates: eatery.coordinates
+        };
         const key = datastore.key(['dining', `${eatery.slug}`]);
         if (EATERYNAME_MAP[eatery.slug] !== null) {
           datastore.upsert(


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is an augmentation to the menu data sync.

- [x] added eatery location information to the datastore.

### Test Plan <!-- Required -->

The database should now update with location information pulled from the Cornell Dining API. In conjunction with the [backend PR 38](https://github.com/cornell-dti/campus-density-backend/pull/38) being deployed, the `/menuData` endpoint should also include this location information.
<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

The new schema:
````
{
    id: "...same as before",
    weeksMenus: [...same as before],
    location: {
        address: "specific building or location, eg. Appel Commons",
        area: "campus area short description, eg. North",
        coordinates: {
            latitude: number,
            longitude: number
        }
    }
}
````
<!--- List any important or subtle points, future considerations, or other items of note. -->