### PR TITLE
Cafe menu bug fix

### DIFF
--- a/functions/dining.js
+++ b/functions/dining.js
@@ -64,7 +64,7 @@ function insertData(data) {
         // TODO: Change it so its 'safer'. Right now, I'm assuming that the
         // first entry in eatery types is a Cafe because that's what it seems
         // to be by inspection.
-        const isDiningHall = eatery.eateryTypes[0].descr == 'Dining Room';
+        const isDiningHall = eatery.eateryTypes[0].descr === 'Dining Room';
         const weeksMenus = isDiningHall
           ? processDiningHalls(eatery.operatingHours)
           : processCafes(eatery.diningItems);

--- a/functions/dining.js
+++ b/functions/dining.js
@@ -103,8 +103,8 @@ function diningData(fnData) {
   } = process.env;
 
   const data = {
-    hostname: 'now.dining.cornell.edu',
-    path: '/api/1.0/dining/eateries.json',
+    hostname: API_ENDPOINT,
+    path: API_PATH,
     headers: {
       Authorization: API_AUTHORIZATION,
       'x-api-key': API_KEY
@@ -116,7 +116,5 @@ function diningData(fnData) {
     .then(() => 'Success')
     .catch(err => console.log(err));
 }
-
-diningData();
 
 exports.handler = diningData;

--- a/functions/dining.js
+++ b/functions/dining.js
@@ -99,16 +99,12 @@ function insertData(data) {
 
 function diningData(fnData) {
   const {
-    API_ENDPOINT, API_PATH, API_AUTHORIZATION, API_KEY
+    API_ENDPOINT, API_PATH
   } = process.env;
 
   const data = {
     hostname: API_ENDPOINT,
-    path: API_PATH,
-    headers: {
-      Authorization: API_AUTHORIZATION,
-      'x-api-key': API_KEY
-    }
+    path: API_PATH
   };
 
   return Util.getJSON(data, https)

--- a/functions/dining.js
+++ b/functions/dining.js
@@ -17,6 +17,7 @@
 
 const https = require('https');
 const Datastore = require('@google-cloud/datastore');
+require('dotenv').config({ path: './.env' });
 
 const datastore = Datastore();
 const Util = require('../src/util');
@@ -63,7 +64,7 @@ function insertData(data) {
         // TODO: Change it so its 'safer'. Right now, I'm assuming that the
         // first entry in eatery types is a Cafe because that's what it seems
         // to be by inspection.
-        const isDiningHall = !!eatery.eateryTypes[0].descr === 'Cafe';
+        const isDiningHall = eatery.eateryTypes[0].descr == 'Dining Room';
         const weeksMenus = isDiningHall
           ? processDiningHalls(eatery.operatingHours)
           : processCafes(eatery.diningItems);
@@ -72,28 +73,24 @@ function insertData(data) {
           area: eatery.campusArea.descrshort,
           coordinates: eatery.coordinates
         };
-
-        console.log(weeksMenus);
         const key = datastore.key(['dining', `${eatery.slug}`]);
+        const menuUpload = {
+          key,
+          data: {
+            id: EATERYNAME_MAP[eatery.slug] || 'unknown',
+            type: isDiningHall ? 'dining-hall' : 'cafe',
+            weeksMenus,
+            location
+          }
+        };
         if (EATERYNAME_MAP[eatery.slug] !== null) {
-          datastore.upsert(
-            {
-              key,
-              data: {
-                id: EATERYNAME_MAP[eatery.slug] || 'unknown',
-                type: isDiningHall ? 'dining-hall' : 'cafe',
-                weeksMenus,
-                location
-              }
-            },
-            err => {
-              if (err) {
-                reject(err);
-                console.log(err);
-              }
-              resolve();
+          datastore.upsert(menuUpload, err => {
+            if (err) {
+              reject(err);
+              console.log(err);
             }
-          );
+            resolve();
+          });
         }
       })
     )
@@ -106,8 +103,8 @@ function diningData(fnData) {
   } = process.env;
 
   const data = {
-    hostname: API_ENDPOINT,
-    path: API_PATH,
+    hostname: 'now.dining.cornell.edu',
+    path: '/api/1.0/dining/eateries.json',
     headers: {
       Authorization: API_AUTHORIZATION,
       'x-api-key': API_KEY
@@ -119,5 +116,7 @@ function diningData(fnData) {
     .then(() => 'Success')
     .catch(err => console.log(err));
 }
+
+diningData();
 
 exports.handler = diningData;


### PR DESCRIPTION
Fix issue with menus not appearing for any cafe's due to incorrect retrieval of data from the Dining API. earlier, we couldn't see the menu's in cafes since the dining Api didn't store the menus in the `events` field in the JSON. There was, instead, a field called `diningItems` that we had to use instead. This PR implements that. Now, there is an additional `type` in the `/menuData` endpoint that signifies whether we're currently parsing a `cafe` or a `dining-hall`. If it's the former, then `weeksMenus` is a static array of strings. Otherwise, it is exactly the same thing as before. 